### PR TITLE
External opengl2 fix

### DIFF
--- a/VruiVTK.cpp
+++ b/VruiVTK.cpp
@@ -3,6 +3,16 @@
 #include <string>
 #include <math.h>
 
+// VTK includes
+#include <ExternalVTKWidget.h>
+#include <vtkActor.h>
+#include <vtkCubeSource.h>
+#include <vtkLight.h>
+#include <vtkNew.h>
+#include <vtkOBJReader.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+
 // OpenGL/Motif includes
 #include <GL/GLContextData.h>
 #include <GL/gl.h>
@@ -23,16 +33,6 @@
 #include <Vrui/Vrui.h>
 #include <Vrui/VRWindow.h>
 #include <Vrui/WindowProperties.h>
-
-// VTK includes
-#include <ExternalVTKWidget.h>
-#include <vtkActor.h>
-#include <vtkCubeSource.h>
-#include <vtkLight.h>
-#include <vtkNew.h>
-#include <vtkOBJReader.h>
-#include <vtkPolyDataMapper.h>
-#include <vtkProperty.h>
 
 // VruiVTK includes
 #include "BaseLocator.h"

--- a/VruiVTK.cpp
+++ b/VruiVTK.cpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <math.h>
 
+// Must come before any gl.h include
+#include <GL/glew.h>
+
 // VTK includes
 #include <ExternalVTKWidget.h>
 #include <vtkActor.h>
@@ -282,6 +285,14 @@ void VruiVTK::frame(void)
 //----------------------------------------------------------------------------
 void VruiVTK::initContext(GLContextData& contextData) const
 {
+  // The VTK OpenGL2 backend seems to require this:
+  GLenum glewInitResult = glewInit();
+  if (glewInitResult != GLEW_OK)
+    {
+    std::cerr << "Error: Could not initialize GLEW (glewInit() returned: "
+              << glewInitResult << ")." << std::endl;
+    }
+
   /* Create a new context data item */
   DataItem* dataItem = new DataItem();
   contextData.addDataItem(this, dataItem);


### PR DESCRIPTION
`glewInit()` wasn't called.

This seems to be required for the new backend. Next time there is a segfault in an OpenGL call and the gl function's address is zero, check if glewInit has been called when the context is created.